### PR TITLE
allow pandas to determine lineterminator for csv file read

### DIFF
--- a/pybpodgui_api/__init__.py
+++ b/pybpodgui_api/__init__.py
@@ -9,7 +9,7 @@ import sys
 import os
 from confapp import conf
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 __author__ = "Ricardo Jorge Vieira Ribeiro"
 __credits__ = ["Ricardo Ribeiro", "Carlos Mão de Ferro", 'Luís Teixeira']
 __license__ = "MIT"

--- a/pybpodgui_api/models/session/session_io.py
+++ b/pybpodgui_api/models/session/session_io.py
@@ -109,7 +109,6 @@ class SessionIO(SessionBase):
                                     delimiter=csv.CSV_DELIMITER,
                                     quotechar=csv.CSV_QUOTECHAR,
                                     quoting=csv.CSV_QUOTING,
-                                    lineterminator=csv.CSV_LINETERMINATOR,
                                     skiprows=nrows,
                                     memory_map=True
                                     )


### PR DESCRIPTION
Regarding issue https://github.com/pybpod/pybpod/issues/103; allowing pandas to determine the line termination seems to correct the issue that we were experiencing.